### PR TITLE
Clean up old irrelevant docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@
 //!   [`map::serde_seq`] module.
 //! * `borsh`: Adds implementations for [`BorshSerialize`] and [`BorshDeserialize`]
 //!   to [`RingMap`] and [`RingSet`].
-//!   `use borsh_derive::{BorshSerialize, BorshDeserialize};`.
 //! * `arbitrary`: Adds implementations for the [`arbitrary::Arbitrary`] trait
 //!   to [`RingMap`] and [`RingSet`].
 //! * `quickcheck`: Adds implementations for the [`quickcheck::Arbitrary`] trait

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -12,9 +12,6 @@ use core::ops::{self, Bound, Index, IndexMut, RangeBounds};
 ///
 /// This supports indexed operations much like a `[(K, V)]` slice,
 /// but not any hashed operations on the map keys.
-///
-/// Unlike `RingMap`, `Slice` does consider the order for [`PartialEq`]
-/// and [`Eq`], and it also implements [`PartialOrd`], [`Ord`], and [`Hash`].
 #[repr(transparent)]
 pub struct Slice<K, V> {
     pub(crate) entries: [Bucket<K, V>],

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -12,9 +12,6 @@ use core::ops::{self, Bound, Index, RangeBounds};
 ///
 /// This supports indexed operations much like a `[T]` slice,
 /// but not any hashed operations on the values.
-///
-/// Unlike `RingSet`, `Slice` does consider the order for [`PartialEq`]
-/// and [`Eq`], and it also implements [`PartialOrd`], [`Ord`], and [`Hash`].
 #[repr(transparent)]
 pub struct Slice<T> {
     pub(crate) entries: [Bucket<T>],


### PR DESCRIPTION
* A note to use `borsh_derive` was part of `indexmap`'s warning about a `borsh/derive` dependency loop -- not relevant to `ringmap`.
* `Slice` comments about order in equality was also a carryover from `indexmap`, but `RingMap`/`RingSet` do also use order.