### PR TITLE
Fix `clippy::needless_lifetimes` and `clippy::type_complexity`

### DIFF
--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -43,13 +43,17 @@ pub(crate) struct Buckets<'a, K, V> {
 
 impl<'a, K, V> Buckets<'a, K, V> {
     pub(crate) fn new(entries: &'a VecDeque<Bucket<K, V>>) -> Self {
-        Self::from_slices(entries.as_slices())
-    }
-
-    pub(crate) fn from_slices((head, tail): (&'a [Bucket<K, V>], &'a [Bucket<K, V>])) -> Self {
+        let (head, tail) = entries.as_slices();
         Self {
             head: head.iter(),
             tail: tail.iter(),
+        }
+    }
+
+    pub(crate) fn from_slice(slice: &'a [Bucket<K, V>]) -> Self {
+        Self {
+            head: slice.iter(),
+            tail: [].iter(),
         }
     }
 }
@@ -148,18 +152,25 @@ struct BucketsMut<'a, K, V> {
 
 impl<'a, K, V> BucketsMut<'a, K, V> {
     fn new(entries: &'a mut VecDeque<Bucket<K, V>>) -> Self {
-        Self::from_mut_slices(entries.as_mut_slices())
-    }
-
-    fn from_mut_slices((head, tail): (&'a mut [Bucket<K, V>], &'a mut [Bucket<K, V>])) -> Self {
+        let (head, tail) = entries.as_mut_slices();
         Self {
             head: head.iter_mut(),
             tail: tail.iter_mut(),
         }
     }
 
+    fn from_mut_slice(slice: &'a mut [Bucket<K, V>]) -> Self {
+        Self {
+            head: slice.iter_mut(),
+            tail: [].iter_mut(),
+        }
+    }
+
     fn iter(&self) -> Buckets<'_, K, V> {
-        Buckets::from_slices((self.head.as_slice(), self.tail.as_slice()))
+        Buckets {
+            head: self.head.as_slice().iter(),
+            tail: self.tail.as_slice().iter(),
+        }
     }
 }
 
@@ -255,9 +266,9 @@ impl<'a, K, V> Iter<'a, K, V> {
         }
     }
 
-    pub(super) fn from_slices(slices: (&'a [Bucket<K, V>], &'a [Bucket<K, V>])) -> Self {
+    pub(super) fn from_slice(slice: &'a [Bucket<K, V>]) -> Self {
         Self {
-            iter: Buckets::from_slices(slices),
+            iter: Buckets::from_slice(slice),
         }
     }
 }
@@ -318,11 +329,9 @@ impl<'a, K, V> IterMut<'a, K, V> {
         }
     }
 
-    pub(super) fn from_mut_slices(
-        slices: (&'a mut [Bucket<K, V>], &'a mut [Bucket<K, V>]),
-    ) -> Self {
+    pub(super) fn from_mut_slice(slice: &'a mut [Bucket<K, V>]) -> Self {
         Self {
-            iter: BucketsMut::from_mut_slices(slices),
+            iter: BucketsMut::from_mut_slice(slice),
         }
     }
 }
@@ -517,9 +526,9 @@ impl<'a, K, V> Keys<'a, K, V> {
         }
     }
 
-    pub(super) fn from_slices(slices: (&'a [Bucket<K, V>], &'a [Bucket<K, V>])) -> Self {
+    pub(super) fn from_slice(slice: &'a [Bucket<K, V>]) -> Self {
         Self {
-            iter: Buckets::from_slices(slices),
+            iter: Buckets::from_slice(slice),
         }
     }
 }
@@ -705,9 +714,9 @@ impl<'a, K, V> Values<'a, K, V> {
         }
     }
 
-    pub(super) fn from_slices(slices: (&'a [Bucket<K, V>], &'a [Bucket<K, V>])) -> Self {
+    pub(super) fn from_slice(slice: &'a [Bucket<K, V>]) -> Self {
         Self {
-            iter: Buckets::from_slices(slices),
+            iter: Buckets::from_slice(slice),
         }
     }
 }
@@ -768,11 +777,9 @@ impl<'a, K, V> ValuesMut<'a, K, V> {
         }
     }
 
-    pub(super) fn from_mut_slices(
-        slices: (&'a mut [Bucket<K, V>], &'a mut [Bucket<K, V>]),
-    ) -> Self {
+    pub(super) fn from_mut_slice(slice: &'a mut [Bucket<K, V>]) -> Self {
         Self {
-            iter: BucketsMut::from_mut_slices(slices),
+            iter: BucketsMut::from_mut_slice(slice),
         }
     }
 }

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -623,7 +623,7 @@ impl<K, V> Default for Keys<'_, K, V> {
 /// map.insert("foo", 1);
 /// println!("{:?}", map.keys()[10]); // panics!
 /// ```
-impl<'a, K, V> Index<usize> for Keys<'a, K, V> {
+impl<K, V> Index<usize> for Keys<'_, K, V> {
     type Output = K;
 
     /// Returns a reference to the key at the supplied `index`.
@@ -975,7 +975,7 @@ where
 {
 }
 
-impl<'a, I, K, V, S> fmt::Debug for Splice<'a, I, K, V, S>
+impl<I, K, V, S> fmt::Debug for Splice<'_, I, K, V, S>
 where
     I: fmt::Debug + Iterator<Item = (K, V)>,
     K: fmt::Debug + Hash + Eq,

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -173,17 +173,17 @@ impl<K, V> Slice<K, V> {
 
     /// Return an iterator over the key-value pairs of the map slice.
     pub fn iter(&self) -> Iter<'_, K, V> {
-        Iter::from_slices((&self.entries, &[]))
+        Iter::from_slice(&self.entries)
     }
 
     /// Return an iterator over the key-value pairs of the map slice.
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
-        IterMut::from_mut_slices((&mut self.entries, &mut []))
+        IterMut::from_mut_slice(&mut self.entries)
     }
 
     /// Return an iterator over the keys of the map slice.
     pub fn keys(&self) -> Keys<'_, K, V> {
-        Keys::from_slices((&self.entries, &[]))
+        Keys::from_slice(&self.entries)
     }
 
     /// Return an owning iterator over the keys of the map slice.
@@ -193,12 +193,12 @@ impl<K, V> Slice<K, V> {
 
     /// Return an iterator over the values of the map slice.
     pub fn values(&self) -> Values<'_, K, V> {
-        Values::from_slices((&self.entries, &[]))
+        Values::from_slice(&self.entries)
     }
 
     /// Return an iterator over mutable references to the the values of the map slice.
     pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
-        ValuesMut::from_mut_slices((&mut self.entries, &mut []))
+        ValuesMut::from_mut_slice(&mut self.entries)
     }
 
     /// Return an owning iterator over the values of the map slice.

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -98,7 +98,7 @@ where
 
     fn into_par_iter(self) -> Self::Iter {
         ParIter {
-            entries: ParBuckets::from_slices((&self.entries, &[])),
+            entries: ParBuckets::from_slice(&self.entries),
         }
     }
 }

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -40,9 +40,9 @@ impl<'a, T> Iter<'a, T> {
         }
     }
 
-    pub(super) fn from_slices(slices: (&'a [Bucket<T>], &'a [Bucket<T>])) -> Self {
+    pub(super) fn from_slice(slice: &'a [Bucket<T>]) -> Self {
         Self {
-            iter: Buckets::from_slices(slices),
+            iter: Buckets::from_slice(slice),
         }
     }
 }

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -607,7 +607,7 @@ impl<I: Iterator> Iterator for UnitValue<I> {
     }
 }
 
-impl<'a, I, T, S> fmt::Debug for Splice<'a, I, T, S>
+impl<I, T, S> fmt::Debug for Splice<'_, I, T, S>
 where
     I: fmt::Debug + Iterator<Item = T>,
     T: fmt::Debug + Hash + Eq,

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -109,7 +109,7 @@ impl<T> Slice<T> {
 
     /// Return an iterator over the values of the set slice.
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter::from_slices((&self.entries, &[]))
+        Iter::from_slice(&self.entries)
     }
 
     /// Search over a sorted set for a value.


### PR DESCRIPTION
The first commit is cherry-picked from indexmap-rs/indexmap#373, and the rest are unique to `ringmap`.