### PR TITLE
Release 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-features = false
 
 [dev-dependencies]
 itertools = "0.14"
-rand = {version = "0.8", features = ["small_rng"] }
+rand = {version = "0.9", features = ["small_rng"] }
 quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
 lazy_static = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ringmap"
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"
 documentation = "https://docs.rs/ringmap/"
 repository = "https://github.com/indexmap-rs/ringmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,9 +1,15 @@
 # Releases
 
-## 0.1.1
+## 0.1.2 (2025-03-10)
+
+- Added `ringmap_with_default!` and `ringset_with_default!` to be used with
+  alternative hashers, especially when using the crate without `std`.
+- Implemented `PartialEq` between each `Slice` and `[]`/arrays.
+
+## 0.1.1 (2025-01-29)
 
 - Optimized the branch behavior of the iterators.
 
-## 0.1.0
+## 0.1.0 (2025-01-21)
 
 - Initial release, based on `indexmap v2.7.1`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,8 @@
 //!   [`with_capacity_and_hasher`][RingMap::with_capacity_and_hasher] instead.
 //!   A no-std compatible hasher will be needed as well, for example
 //!   from the crate `twox-hash`.
-//! - Macros [`ringmap!`] and [`ringset!`] are unavailable without `std`.
+//! - Macros [`ringmap!`] and [`ringset!`] are unavailable without `std`. Use
+//!   the macros [`ringmap_with_default!`] and [`ringset_with_default!`] instead.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,40 @@
+/// Create an [`RingMap`][crate::RingMap] from a list of key-value pairs
+/// and a `BuildHasherDefault`-wrapped custom hasher.
+///
+/// ## Example
+///
+/// ```
+/// use ringmap::ringmap_with_default;
+/// use fnv::FnvHasher;
+///
+/// let map = ringmap_with_default!{
+///     FnvHasher;
+///     "a" => 1,
+///     "b" => 2,
+/// };
+/// assert_eq!(map["a"], 1);
+/// assert_eq!(map["b"], 2);
+/// assert_eq!(map.get("c"), None);
+///
+/// // "a" is the first key
+/// assert_eq!(map.keys().next(), Some(&"a"));
+/// ```
+#[macro_export]
+macro_rules! ringmap_with_default {
+    ($H:ty; $($key:expr => $value:expr,)+) => { $crate::ringmap_with_default!($H; $($key => $value),+) };
+    ($H:ty; $($key:expr => $value:expr),*) => {{
+        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
+        #[allow(unused_mut)]
+        // Specify your custom `H` (must implement Default + Hasher) as the hasher:
+        let mut map = $crate::RingMap::with_capacity_and_hasher(CAP, builder);
+        $(
+            map.insert($key, $value);
+        )*
+        map
+    }};
+}
+
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
@@ -33,6 +70,43 @@ macro_rules! ringmap {
             map
         }
     };
+}
+
+/// Create an [`RingSet`][crate::RingSet] from a list of values
+/// and a `BuildHasherDefault`-wrapped custom hasher.
+///
+/// ## Example
+///
+/// ```
+/// use ringmap::ringset_with_default;
+/// use fnv::FnvHasher;
+///
+/// let set = ringset_with_default!{
+///     FnvHasher;
+///     "a",
+///     "b",
+/// };
+/// assert!(set.contains("a"));
+/// assert!(set.contains("b"));
+/// assert!(!set.contains("c"));
+///
+/// // "a" is the first value
+/// assert_eq!(set.iter().next(), Some(&"a"));
+/// ```
+#[macro_export]
+macro_rules! ringset_with_default {
+    ($H:ty; $($value:expr,)+) => { $crate::ringset_with_default!($H; $($value),+) };
+    ($H:ty; $($value:expr),*) => {{
+        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
+        #[allow(unused_mut)]
+        // Specify your custom `H` (must implement Default + Hash) as the hasher:
+        let mut set = $crate::RingSet::with_capacity_and_hasher(CAP, builder);
+        $(
+            set.insert($value);
+        )*
+        set
+    }};
 }
 
 #[cfg(feature = "std")]

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -626,8 +626,8 @@ impl<K, V> Default for Keys<'_, K, V> {
 /// [values]: RingMap#impl-Index<usize>-for-RingMap<K,+V,+S>
 ///
 /// Since `Keys` is also an iterator, consuming items from the iterator will
-/// offset the effective indexes. Similarly, if `Keys` is obtained from
-/// [`Slice::keys`][super::Slice::keys], indexes will be interpreted relative to the position of
+/// offset the effective indices. Similarly, if `Keys` is obtained from
+/// [`Slice::keys`][super::Slice::keys], indices will be interpreted relative to the position of
 /// that slice.
 ///
 /// # Examples

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -335,6 +335,22 @@ impl<K: PartialEq, V: PartialEq> PartialEq for Slice<K, V> {
     }
 }
 
+impl<K: PartialEq, V: PartialEq> PartialEq<[(K, V)]> for Slice<K, V> {
+    fn eq(&self, other: &[(K, V)]) -> bool {
+        self.len() == other.len() &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+    }
+}
+
+impl<K: PartialEq, V: PartialEq> PartialEq<Slice<K, V>> for [(K, V)] {
+    fn eq(&self, other: &Slice<K, V>) -> bool {
+        self.len() == other.len() &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().map(|(k, v)| (k, v)).eq(other)
+    }
+}
+
 impl<K: Eq, V: Eq> Eq for Slice<K, V> {}
 
 impl<K: PartialOrd, V: PartialOrd> PartialOrd for Slice<K, V> {

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -351,6 +351,22 @@ impl<K: PartialEq, V: PartialEq> PartialEq<Slice<K, V>> for [(K, V)] {
     }
 }
 
+impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<[(K, V); N]> for Slice<K, V> {
+    fn eq(&self, other: &[(K, V); N]) -> bool {
+        self.len() == N &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+    }
+}
+
+impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<Slice<K, V>> for [(K, V); N] {
+    fn eq(&self, other: &Slice<K, V>) -> bool {
+        N == other.len() &&
+            // mapping from `&(K, V)` to `(&K, &V)`
+            self.iter().map(|(k, v)| (k, v)).eq(other)
+    }
+}
+
 impl<K: Eq, V: Eq> Eq for Slice<K, V> {}
 
 impl<K: PartialOrd, V: PartialOrd> PartialOrd for Slice<K, V> {

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -1,5 +1,5 @@
 use super::{Bucket, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::util::try_simplify_range;
+use crate::util::{slice_eq, try_simplify_range};
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
@@ -329,41 +329,55 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Slice<K, V> {
     }
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq for Slice<K, V> {
-    fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<K, V, K2, V2> PartialEq<Slice<K2, V2>> for Slice<K, V>
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &Slice<K2, V2>) -> bool {
+        slice_eq(&self.entries, &other.entries, |b1, b2| {
+            b1.key == b2.key && b1.value == b2.value
+        })
     }
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq<[(K, V)]> for Slice<K, V> {
-    fn eq(&self, other: &[(K, V)]) -> bool {
-        self.len() == other.len() &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+impl<K, V, K2, V2> PartialEq<[(K2, V2)]> for Slice<K, V>
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &[(K2, V2)]) -> bool {
+        slice_eq(&self.entries, other, |b, t| b.key == t.0 && b.value == t.1)
     }
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq<Slice<K, V>> for [(K, V)] {
-    fn eq(&self, other: &Slice<K, V>) -> bool {
-        self.len() == other.len() &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().map(|(k, v)| (k, v)).eq(other)
+impl<K, V, K2, V2> PartialEq<Slice<K2, V2>> for [(K, V)]
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &Slice<K2, V2>) -> bool {
+        slice_eq(self, &other.entries, |t, b| t.0 == b.key && t.1 == b.value)
     }
 }
 
-impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<[(K, V); N]> for Slice<K, V> {
-    fn eq(&self, other: &[(K, V); N]) -> bool {
-        self.len() == N &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().eq(other.iter().map(|(k, v)| (k, v)))
+impl<K, V, K2, V2, const N: usize> PartialEq<[(K2, V2); N]> for Slice<K, V>
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &[(K2, V2); N]) -> bool {
+        <Self as PartialEq<[_]>>::eq(self, other)
     }
 }
 
-impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq<Slice<K, V>> for [(K, V); N] {
-    fn eq(&self, other: &Slice<K, V>) -> bool {
-        N == other.len() &&
-            // mapping from `&(K, V)` to `(&K, &V)`
-            self.iter().map(|(k, v)| (k, v)).eq(other)
+impl<K, V, const N: usize, K2, V2> PartialEq<Slice<K2, V2>> for [(K, V); N]
+where
+    K: PartialEq<K2>,
+    V: PartialEq<V2>,
+{
+    fn eq(&self, other: &Slice<K2, V2>) -> bool {
+        <[_] as PartialEq<_>>::eq(self, other)
     }
 }
 

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -237,6 +237,18 @@ impl<T: PartialEq> PartialEq<Slice<T>> for [T] {
     }
 }
 
+impl<T: PartialEq, const N: usize> PartialEq<[T; N]> for Slice<T> {
+    fn eq(&self, other: &[T; N]) -> bool {
+        self.len() == N && self.iter().eq(other)
+    }
+}
+
+impl<T: PartialEq, const N: usize> PartialEq<Slice<T>> for [T; N] {
+    fn eq(&self, other: &Slice<T>) -> bool {
+        N == other.len() && self.iter().eq(other)
+    }
+}
+
 impl<T: Eq> Eq for Slice<T> {}
 
 impl<T: PartialOrd> PartialOrd for Slice<T> {

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -225,6 +225,18 @@ impl<T: PartialEq> PartialEq for Slice<T> {
     }
 }
 
+impl<T: PartialEq> PartialEq<[T]> for Slice<T> {
+    fn eq(&self, other: &[T]) -> bool {
+        self.len() == other.len() && self.iter().eq(other)
+    }
+}
+
+impl<T: PartialEq> PartialEq<Slice<T>> for [T] {
+    fn eq(&self, other: &Slice<T>) -> bool {
+        self.len() == other.len() && self.iter().eq(other)
+    }
+}
+
 impl<T: Eq> Eq for Slice<T> {}
 
 impl<T: PartialOrd> PartialOrd for Slice<T> {

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -1,5 +1,5 @@
 use super::{Bucket, IntoIter, Iter};
-use crate::util::try_simplify_range;
+use crate::util::{slice_eq, try_simplify_range};
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
@@ -219,33 +219,48 @@ impl<T: fmt::Debug> fmt::Debug for Slice<T> {
     }
 }
 
-impl<T: PartialEq> PartialEq for Slice<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<T, U> PartialEq<Slice<U>> for Slice<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Slice<U>) -> bool {
+        slice_eq(&self.entries, &other.entries, |b1, b2| b1.key == b2.key)
     }
 }
 
-impl<T: PartialEq> PartialEq<[T]> for Slice<T> {
-    fn eq(&self, other: &[T]) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<T, U> PartialEq<[U]> for Slice<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &[U]) -> bool {
+        slice_eq(&self.entries, other, |b, o| b.key == *o)
     }
 }
 
-impl<T: PartialEq> PartialEq<Slice<T>> for [T] {
-    fn eq(&self, other: &Slice<T>) -> bool {
-        self.len() == other.len() && self.iter().eq(other)
+impl<T, U> PartialEq<Slice<U>> for [T]
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Slice<U>) -> bool {
+        slice_eq(self, &other.entries, |o, b| *o == b.key)
     }
 }
 
-impl<T: PartialEq, const N: usize> PartialEq<[T; N]> for Slice<T> {
-    fn eq(&self, other: &[T; N]) -> bool {
-        self.len() == N && self.iter().eq(other)
+impl<T, U, const N: usize> PartialEq<[U; N]> for Slice<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &[U; N]) -> bool {
+        <Self as PartialEq<[U]>>::eq(self, other)
     }
 }
 
-impl<T: PartialEq, const N: usize> PartialEq<Slice<T>> for [T; N] {
-    fn eq(&self, other: &Slice<T>) -> bool {
-        N == other.len() && self.iter().eq(other)
+impl<T, const N: usize, U> PartialEq<Slice<U>> for [T; N]
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Slice<U>) -> bool {
+        <[T] as PartialEq<Slice<U>>>::eq(self, other)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,3 +56,23 @@ where
     }
     Some(start..end)
 }
+
+// Generic slice equality -- copied from the standard library but adding a custom comparator,
+// allowing for our `Bucket` wrapper on either or both sides.
+pub(crate) fn slice_eq<T, U>(left: &[T], right: &[U], eq: impl Fn(&T, &U) -> bool) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+
+    // Implemented as explicit indexing rather
+    // than zipped iterators for performance reasons.
+    // See PR https://github.com/rust-lang/rust/pull/116846
+    for i in 0..left.len() {
+        // bound checks are optimized away
+        if !eq(&left[i], &right[i]) {
+            return false;
+        }
+    }
+
+    true
+}


### PR DESCRIPTION
- Added `ringmap_with_default!` and `ringset_with_default!` to be used with
  alternative hashers, especially when using the crate without `std`.
- Implemented `PartialEq` between each `Slice` and `[]`/arrays.