### PR TITLE
Release 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ringmap"
 edition = "2021"
-version = "0.1.5"
+version = "0.1.6"
 documentation = "https://docs.rs/ringmap/"
 repository = "https://github.com/indexmap-rs/ringmap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 0.1.6 (2025-09-08)
+
+- Added a `get_key_value_mut` method to `RingMap`.
+- Removed the unnecessary `Ord` bound on `insert_sorted_by` methods.
+
 ## 0.1.5 (2025-08-22)
 
 - Added `insert_sorted_by` and `insert_sorted_by_key` methods to `RingMap`,

--- a/src/map.rs
+++ b/src/map.rs
@@ -542,7 +542,6 @@ where
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(&mut self, key: K, value: V, mut cmp: F) -> (usize, Option<V>)
     where
-        K: Ord,
         F: FnMut(&K, &V, &K, &V) -> Ordering,
     {
         let (Ok(i) | Err(i)) = self.binary_search_by(|k, v| cmp(k, v, &key, &value));

--- a/src/map.rs
+++ b/src/map.rs
@@ -863,7 +863,7 @@ where
         self.get_index_of(key).is_some()
     }
 
-    /// Return a reference to the value stored for `key`, if it is present,
+    /// Return a reference to the stored value for `key`, if it is present,
     /// else `None`.
     ///
     /// Computes in **O(1)** time (average).
@@ -879,7 +879,7 @@ where
         }
     }
 
-    /// Return references to the key-value pair stored for `key`,
+    /// Return references to the stored key-value pair for the lookup `key`,
     /// if it is present, else `None`.
     ///
     /// Computes in **O(1)** time (average).
@@ -895,7 +895,10 @@ where
         }
     }
 
-    /// Return item index, key and value
+    /// Return the index with references to the stored key-value pair for the
+    /// lookup `key`, if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn get_full<Q>(&self, key: &Q) -> Option<(usize, &K, &V)>
     where
         Q: ?Sized + Hash + Equivalent<K>,
@@ -908,7 +911,7 @@ where
         }
     }
 
-    /// Return item index, if it exists in the map
+    /// Return the item index for `key`, if it is present, else `None`.
     ///
     /// Computes in **O(1)** time (average).
     pub fn get_index_of<Q>(&self, key: &Q) -> Option<usize>
@@ -925,6 +928,10 @@ where
         }
     }
 
+    /// Return a mutable reference to the stored value for `key`,
+    /// if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
         Q: ?Sized + Hash + Equivalent<K>,
@@ -937,8 +944,8 @@ where
         }
     }
 
-    /// Return references to the key-value pair stored for `key`,
-    /// if it is present, else `None`.
+    /// Return a reference and mutable references to the stored key-value pair
+    /// for the lookup `key`, if it is present, else `None`.
     ///
     /// Computes in **O(1)** time (average).
     pub fn get_key_value_mut<Q>(&mut self, key: &Q) -> Option<(&K, &mut V)>
@@ -953,6 +960,10 @@ where
         }
     }
 
+    /// Return the index with a reference and mutable reference to the stored
+    /// key-value pair for the lookup `key`, if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn get_full_mut<Q>(&mut self, key: &Q) -> Option<(usize, &K, &mut V)>
     where
         Q: ?Sized + Hash + Equivalent<K>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -937,6 +937,22 @@ where
         }
     }
 
+    /// Return references to the key-value pair stored for `key`,
+    /// if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn get_key_value_mut<Q>(&mut self, key: &Q) -> Option<(&K, &mut V)>
+    where
+        Q: ?Sized + Hash + Equivalent<K>,
+    {
+        if let Some(i) = self.get_index_of(key) {
+            let entry = &mut self.as_entries_mut()[i];
+            Some((&entry.key, &mut entry.value))
+        } else {
+            None
+        }
+    }
+
     pub fn get_full_mut<Q>(&mut self, key: &Q) -> Option<(usize, &K, &mut V)>
     where
         Q: ?Sized + Hash + Equivalent<K>,

--- a/src/map/core/entry.rs
+++ b/src/map/core/entry.rs
@@ -469,7 +469,6 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(self, value: V, mut cmp: F) -> (usize, &'a mut V)
     where
-        K: Ord,
         F: FnMut(&K, &V, &K, &V) -> Ordering,
     {
         let (Ok(i) | Err(i)) = self

--- a/src/set.rs
+++ b/src/set.rs
@@ -464,7 +464,6 @@ where
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(&mut self, value: T, mut cmp: F) -> (usize, bool)
     where
-        T: Ord,
         F: FnMut(&T, &T) -> Ordering,
     {
         let (index, existing) = self


### PR DESCRIPTION
- Added a `get_key_value_mut` method to `RingMap`.
- Removed the unnecessary `Ord` bound on `insert_sorted_by` methods.