### PR TITLE
Release 0.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.82.0 # MSRV
+          - rust: 1.85.0 # MSRV
             features:
           - rust: stable
             features: arbitrary
@@ -40,12 +40,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Lock MSRV-compatible dependencies
-        if: matrix.rust == '1.82.0'
-        env:
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
-        # Note that this uses the runner's pre-installed stable cargo
-        run: cargo generate-lockfile
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -72,19 +66,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.82.0
+          - rust: 1.85.0
             target: thumbv6m-none-eabi
           - rust: stable
             target: thumbv6m-none-eabi
 
     steps:
       - uses: actions/checkout@v4
-      - name: Lock MSRV-compatible dependencies
-        if: matrix.rust == '1.82.0'
-        env:
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
-        # Note that this uses the runner's pre-installed stable cargo
-        run: cargo generate-lockfile
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -124,14 +112,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: dtolnay/rust-toolchain@1.82.0 # MSRV
+      - uses: dtolnay/rust-toolchain@1.85.0 # MSRV
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
       - name: Lock minimal direct dependencies
         run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z direct-minimal-versions
-        env:
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Build (nightly)
         run: cargo +nightly build --verbose --all-features
       - name: Build (MSRV)

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2021"
+edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 
 [dependencies]
 equivalent = { version = "1.0", default-features = false }
-hashbrown = { version = "0.16.1", default-features = false }
+hashbrown = { version = "0.17", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "ringmap"
-edition = "2021"
-version = "0.2.4"
+edition = "2024"
+version = "0.2.5"
 documentation = "https://docs.rs/ringmap/"
 repository = "https://github.com/indexmap-rs/ringmap"
 license = "Apache-2.0 OR MIT"
 description = "A hash table with consistent deque-like order and fast iteration."
 keywords = ["hashmap", "no_std"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.82"
+rust-version = "1.85"
 
 [lib]
 bench = false
@@ -32,7 +32,7 @@ serde = { version = "1.0.220", default-features = false, optional = true }
 [dev-dependencies]
 itertools = "0.14"
 fastrand = { version = "2", default-features = false }
-quickcheck = { version = "1.0", default-features = false }
+quickcheck = { version = "1.1", default-features = false }
 fnv = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://github.com/indexmap-rs/ringmap/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/indexmap-rs/ringmap/actions)
 [![crates.io](https://img.shields.io/crates/v/ringmap.svg)](https://crates.io/crates/ringmap)
 [![docs](https://docs.rs/ringmap/badge.svg)](https://docs.rs/ringmap)
-[![rustc](https://img.shields.io/badge/rust-1.82%2B-orange.svg)](https://img.shields.io/badge/rust-1.82%2B-orange.svg)
+[![rustc](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://img.shields.io/badge/rust-1.85%2B-orange.svg)
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order,
 with efficient deque-like manipulation of both the front and back ends.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 0.2.5 (2026-04-09)
+
+- **MSRV**: Rust 1.85.0 or later is now required.
+- Updated the `hashbrown` dependency to 0.17.
+- Made more `map::Slice` methods `const`: `new_mut`, `first_mut`, `last_mut`,
+  `split_at_mut`, `split_at_mut_checked`, `split_first_mut`, `split_last_mut`
+
 ## 0.2.4 (2026-04-02)
 
 - Made some `Slice` methods `const`:

--- a/src/inner/entry.rs
+++ b/src/inner/entry.rs
@@ -1,6 +1,6 @@
-use super::{equivalent, get_hash, Bucket, Core, OffsetIndex};
-use crate::map::{Entry, IndexedEntry};
+use super::{Bucket, Core, OffsetIndex, equivalent, get_hash};
 use crate::HashValue;
+use crate::map::{Entry, IndexedEntry};
 use core::cmp::Ordering;
 use core::mem;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ impl<K, V> Bucket<K, V> {
     const fn value_ref(&self) -> &V {
         &self.value
     }
-    fn value_mut(&mut self) -> &mut V {
+    const fn value_mut(&mut self) -> &mut V {
         &mut self.value
     }
     fn key(self) -> K {
@@ -191,10 +191,10 @@ impl<K, V> Bucket<K, V> {
     const fn refs(&self) -> (&K, &V) {
         (&self.key, &self.value)
     }
-    fn ref_mut(&mut self) -> (&K, &mut V) {
+    const fn ref_mut(&mut self) -> (&K, &mut V) {
         (&self.key, &mut self.value)
     }
-    fn muts(&mut self) -> (&mut K, &mut V) {
+    const fn muts(&mut self) -> (&mut K, &mut V) {
         (&mut self.key, &mut self.value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of ringmap requires Rust 1.82 or later.
+//! This version of ringmap requires Rust 1.85 or later.
 //!
 //! The ringmap 0.2 release series will use a carefully considered version
 //! upgrade policy, where in a later 0.x version, we will raise the minimum

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@
 macro_rules! ringmap_with_default {
     ($H:ty; $($key:expr => $value:expr,)+) => { $crate::ringmap_with_default!($H; $($key => $value),+) };
     ($H:ty; $($key:expr => $value:expr),*) => {{
-        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        let builder = ::core::hash::BuildHasherDefault::<$H>::new();
         const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
         #[allow(unused_mut)]
         // Specify your custom `H` (must implement Default + Hasher) as the hasher:
@@ -97,7 +97,7 @@ macro_rules! ringmap {
 macro_rules! ringset_with_default {
     ($H:ty; $($value:expr,)+) => { $crate::ringset_with_default!($H; $($value),+) };
     ($H:ty; $($value:expr),*) => {{
-        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        let builder = ::core::hash::BuildHasherDefault::<$H>::new();
         const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
         #[allow(unused_mut)]
         // Specify your custom `H` (must implement Default + Hash) as the hasher:

--- a/src/map.rs
+++ b/src/map.rs
@@ -968,7 +968,9 @@ where
         }
     }
 
-    /// Return the values for `N` keys. If any key is duplicated, this function will panic.
+    /// Return the values for `N` keys.
+    ///
+    /// ***Panics*** if any key is duplicated.
     ///
     /// # Examples
     ///
@@ -976,6 +978,7 @@ where
     /// let mut map = ringmap::RingMap::from([(1, 'a'), (3, 'b'), (2, 'c')]);
     /// assert_eq!(map.get_disjoint_mut([&2, &1]), [Some(&mut 'c'), Some(&mut 'a')]);
     /// ```
+    #[track_caller]
     pub fn get_disjoint_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
     where
         Q: ?Sized + Hash + Equivalent<K>,

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -25,10 +25,10 @@ use core::fmt::{self, Formatter};
 use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
 
+use crate::RingMap;
 use crate::map::Slice as MapSlice;
 use crate::serde::cautious_capacity;
 use crate::set::Slice as SetSlice;
-use crate::RingMap;
 
 /// Serializes a [`map::Slice`][MapSlice] as an ordered sequence.
 ///

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -1,6 +1,6 @@
 use super::{Bucket, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::util::{slice_eq, try_simplify_range};
 use crate::GetDisjointMutError;
+use crate::util::{slice_eq, try_simplify_range};
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -26,7 +26,7 @@ impl<K, V> Slice<K, V> {
         unsafe { &*(entries as *const [Bucket<K, V>] as *const Self) }
     }
 
-    pub(super) fn from_mut_slice(entries: &mut [Bucket<K, V>]) -> &mut Self {
+    pub(super) const fn from_mut_slice(entries: &mut [Bucket<K, V>]) -> &mut Self {
         unsafe { &mut *(entries as *mut [Bucket<K, V>] as *mut Self) }
     }
 
@@ -50,7 +50,7 @@ impl<K, V> Slice<K, V> {
     }
 
     /// Returns an empty mutable slice.
-    pub fn new_mut<'a>() -> &'a mut Self {
+    pub const fn new_mut<'a>() -> &'a mut Self {
         Self::from_mut_slice(&mut [])
     }
 
@@ -106,8 +106,12 @@ impl<K, V> Slice<K, V> {
     }
 
     /// Get the first key-value pair, with mutable access to the value.
-    pub fn first_mut(&mut self) -> Option<(&K, &mut V)> {
-        self.entries.first_mut().map(Bucket::ref_mut)
+    pub const fn first_mut(&mut self) -> Option<(&K, &mut V)> {
+        if let [first, ..] = &mut self.entries {
+            Some(first.ref_mut())
+        } else {
+            None
+        }
     }
 
     /// Get the last key-value pair.
@@ -120,8 +124,12 @@ impl<K, V> Slice<K, V> {
     }
 
     /// Get the last key-value pair, with mutable access to the value.
-    pub fn last_mut(&mut self) -> Option<(&K, &mut V)> {
-        self.entries.last_mut().map(Bucket::ref_mut)
+    pub const fn last_mut(&mut self) -> Option<(&K, &mut V)> {
+        if let [.., last] = &mut self.entries {
+            Some(last.ref_mut())
+        } else {
+            None
+        }
     }
 
     /// Divides one slice into two at an index.
@@ -139,7 +147,7 @@ impl<K, V> Slice<K, V> {
     /// ***Panics*** if `index > len`.
     /// For a non-panicking alternative see [`split_at_mut_checked`][Self::split_at_mut_checked].
     #[track_caller]
-    pub fn split_at_mut(&mut self, index: usize) -> (&mut Self, &mut Self) {
+    pub const fn split_at_mut(&mut self, index: usize) -> (&mut Self, &mut Self) {
         let (first, second) = self.entries.split_at_mut(index);
         (Self::from_mut_slice(first), Self::from_mut_slice(second))
     }
@@ -158,9 +166,12 @@ impl<K, V> Slice<K, V> {
     /// Divides one mutable slice into two at an index.
     ///
     /// Returns `None` if `index > len`.
-    pub fn split_at_mut_checked(&mut self, index: usize) -> Option<(&mut Self, &mut Self)> {
-        let (first, second) = self.entries.split_at_mut_checked(index)?;
-        Some((Self::from_mut_slice(first), Self::from_mut_slice(second)))
+    pub const fn split_at_mut_checked(&mut self, index: usize) -> Option<(&mut Self, &mut Self)> {
+        if let Some((first, second)) = self.entries.split_at_mut_checked(index) {
+            Some((Self::from_mut_slice(first), Self::from_mut_slice(second)))
+        } else {
+            None
+        }
     }
 
     /// Returns the first key-value pair and the rest of the slice,
@@ -175,7 +186,7 @@ impl<K, V> Slice<K, V> {
 
     /// Returns the first key-value pair and the rest of the slice,
     /// with mutable access to the value, or `None` if it is empty.
-    pub fn split_first_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
+    pub const fn split_first_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
         if let [first, rest @ ..] = &mut self.entries {
             Some((first.ref_mut(), Self::from_mut_slice(rest)))
         } else {
@@ -195,7 +206,7 @@ impl<K, V> Slice<K, V> {
 
     /// Returns the last key-value pair and the rest of the slice,
     /// with mutable access to the value, or `None` if it is empty.
-    pub fn split_last_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
+    pub const fn split_last_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
         if let [rest @ .., last] = &mut self.entries {
             Some((last.ref_mut(), Self::from_mut_slice(rest)))
         } else {

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -15,9 +15,9 @@ use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::ops::RangeBounds;
 
-use crate::map::Slice;
 use crate::Bucket;
 use crate::RingMap;
+use crate::map::Slice;
 
 impl<K, V, S> IntoParallelIterator for RingMap<K, V, S>
 where

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -16,8 +16,8 @@ use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::ops::RangeBounds;
 
-use crate::set::Slice;
 use crate::RingSet;
+use crate::set::Slice;
 
 type Bucket<T> = crate::Bucket<T, ()>;
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -13,9 +13,9 @@ pub use self::iter::{
 pub use self::mutable::MutableValues;
 pub use self::slice::Slice;
 
+use crate::TryReserveError;
 #[cfg(feature = "rayon")]
 pub use crate::rayon::set as rayon;
-use crate::TryReserveError;
 
 #[cfg(feature = "std")]
 use std::hash::RandomState;

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -1,5 +1,5 @@
-use crate::inner::extract::ExtractCore;
 use crate::inner::Core;
+use crate::inner::extract::ExtractCore;
 
 use super::{Bucket, RingSet};
 use crate::map::Buckets;

--- a/test-nostd/Cargo.toml
+++ b/test-nostd/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "test-nostd"
-version = "0.1.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies.ringmap]
 path = ".."

--- a/test-serde/Cargo.toml
+++ b/test-serde/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "test-serde"
-version = "0.1.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/test-serde/src/lib.rs
+++ b/test-serde/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use fnv::FnvBuildHasher;
-use ringmap::{ringmap, ringset, RingMap, RingSet};
+use ringmap::{RingMap, RingSet, ringmap, ringset};
 use serde::{Deserialize, Serialize};
-use serde_test::{assert_tokens, Token};
+use serde_test::{Token, assert_tokens};
 
 #[test]
 fn test_serde_map() {

--- a/test-sval/Cargo.toml
+++ b/test-sval/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "test-sval"
-version = "0.1.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/test-sval/src/lib.rs
+++ b/test-sval/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use fnv::FnvBuildHasher;
-use ringmap::{ringmap, ringset, RingMap, RingSet};
-use sval_test::{assert_tokens, Token};
+use ringmap::{RingMap, RingSet, ringmap, ringset};
+use sval_test::{Token, assert_tokens};
 
 #[test]
 fn test_sval_map() {

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -1,5 +1,5 @@
-use ringmap::ringmap;
 use ringmap::Equivalent;
+use ringmap::ringmap;
 
 use std::hash::Hash;
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -557,10 +557,11 @@ where
 
     // Check both iteration order and hash lookups
     assert!(map.keys().eq(vec.iter()));
-    assert!(vec
-        .iter()
-        .enumerate()
-        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    assert!(
+        vec.iter()
+            .enumerate()
+            .all(|(i, x)| { map.get_index_of(x) == Some(i) })
+    );
     TestResult::passed()
 }
 
@@ -584,10 +585,11 @@ where
 
     // Check both iteration order and hash lookups
     assert!(map.keys().eq(vec.iter()));
-    assert!(vec
-        .iter()
-        .enumerate()
-        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    assert!(
+        vec.iter()
+            .enumerate()
+            .all(|(i, x)| { map.get_index_of(x) == Some(i) })
+    );
     TestResult::passed()
 }
 
@@ -613,10 +615,11 @@ where
 
     // Check both iteration order and hash lookups
     assert!(map.keys().eq(vec.iter()));
-    assert!(vec
-        .iter()
-        .enumerate()
-        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    assert!(
+        vec.iter()
+            .enumerate()
+            .all(|(i, x)| { map.get_index_of(x) == Some(i) })
+    );
     TestResult::passed()
 }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -61,7 +61,7 @@ macro_rules! quickcheck_limit {
                     let mut quickcheck = QuickCheck::new();
                     if cfg!(miri) {
                         quickcheck = quickcheck
-                            .gen(Gen::new(10))
+                            .rng(Gen::new(10))
                             .tests(10)
                             .max_tests(100);
                     }
@@ -219,7 +219,7 @@ quickcheck_limit! {
                 }
             }
         }
-        let hsorted = hmap.iter().sorted_by_key(|(&k, _)| (k.unsigned_abs(), k));
+        let hsorted = hmap.iter().sorted_by_key(|&(&k, _)| (k.unsigned_abs(), k));
         itertools::assert_equal(hsorted, &map);
         itertools::assert_equal(&map, &map2);
         true


### PR DESCRIPTION
- **MSRV**: Rust 1.85.0 or later is now required.
- Updated the `hashbrown` dependency to 0.17.
- Made more `map::Slice` methods `const`: `new_mut`, `first_mut`, `last_mut`,
  `split_at_mut`, `split_at_mut_checked`, `split_first_mut`, `split_last_mut`